### PR TITLE
Baseline RFD XSD + WSDL files

### DIFF
--- a/schema/rfd/RFD.xsd
+++ b/schema/rfd/RFD.xsd
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  IHE Retrieve Form for Data Capture (RFD) XML Schema
+  for usage in WSDL definitions.
+  
+  Distributed in package 4 for 2009 Trial Implementation
+  -->
+<xs:schema xmlns="urn:ihe:iti:rfd:2007" 
+   xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+   xmlns:ihe="urn:ihe:iti:rfd:2007" 
+   targetNamespace="urn:ihe:iti:rfd:2007" 
+   elementFormDefault="qualified">
+	<xs:complexType name="anyXMLContentType">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="skip" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="workflowDataType">
+		<xs:sequence>
+			<xs:element name="formID" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						The identifier of the form to be retrieved.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="encodedResponse" type="xs:boolean" default="true">
+				<xs:annotation>
+					<xs:documentation>
+						true - return either Structured or Unstructured inline form
+						content false - return a URL to the form
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="archiveURL" type="xs:anyURI" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						The URL that the Form Filler provides to the Form Manager so
+						that the returned form can have the archive location prefilled.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="context" type="anyXMLContentType" nillable="true">
+				<xs:annotation>
+					<xs:documentation>tbd an IHE Content Profile</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="instanceID" type="xs:string" nillable="true">
+				<xs:annotation>
+					<xs:documentation> An optional form instanceID returned by the Form Manager</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="clarificationDataType">
+		<xs:sequence>
+			<xs:element name="orgID" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						The identifier of the organization for which clarifications are to be retrieved.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="encodedResponse" type="xs:boolean" default="true">
+				<xs:annotation>
+					<xs:documentation>
+						true - return either Structured or Unstructured inline form
+						content false - return a URL to the form
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="archiveURL" type="xs:anyURI" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						The URL that the Form Filler provides to the Form Manager so
+						that the returned form can have the archive location prefilled.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="context" type="anyXMLContentType" nillable="true">
+				<xs:annotation>
+					<xs:documentation>tbd an IHE Content Profile</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="formDataType">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Structured" type="anyXMLContentType">
+					<xs:annotation>
+						<xs:documentation>XML encoding of form</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="Unstructured" type="xs:base64Binary">
+					<xs:annotation>
+						<xs:documentation> base64Binary encoding of from </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="URL" type="xs:anyURI">
+					<xs:annotation>
+						<xs:documentation> URL of form that can be directly launched into a web browser
+							application </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RetrieveFormRequestType">
+		<xs:sequence>
+			<xs:element name="prepopData" type="anyXMLContentType" nillable="true">
+				<xs:annotation>
+					<xs:documentation> Include the XML to provide the context for the form to be
+						retrieved, and optionally data to be used by the FormManager to prefill the
+						form prior to returning. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="workflowData" type="workflowDataType" nillable="true">
+				<xs:annotation>
+					<xs:documentation>
+						Includes the workflow data, including the formID, necessary for form retrieval.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="RetrieveFormRequest" type="RetrieveFormRequestType"/>
+	<xs:complexType name="RetrieveFormResponseType">
+		<xs:sequence>
+			<xs:element name="form" type="formDataType">
+				<xs:annotation>
+					<xs:documentation>The retrieved form and optional associated information</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="contentType" type="xs:string">
+				<xs:annotation>
+					<xs:documentation> The MIME type associated with the retrieved form. This is
+						has no meaning when encodedResponse='false'. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="responseCode" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="RetrieveFormResponse" type="RetrieveFormResponseType"/>
+	<xs:element name="SubmitFormRequest" type="anyXMLContentType"/>
+	<xs:complexType name="SubmitFormResponseType">
+		<xs:sequence>
+			<xs:element name="content" type="formDataType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If there is a content to be returned based on a subsequent
+						need to have the FormFiller present a form, then it would be present there.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="contentType" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation> The MIME type associated with the response content. The
+						submitting form will be designed in such a way that works in coordination
+						with a FormReceiver that returns this. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="responseCode" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="SubmitFormResponse" type="SubmitFormResponseType"/>
+	<xs:element name="ArchiveFormRequest" type="anyXMLContentType"/>
+	<xs:complexType name="ArchiveFormResponseType">
+		<xs:sequence>
+			<xs:element name="responseCode" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="ArchiveFormResponse" type="ArchiveFormResponseType"/>
+	<xs:complexType name="RetrieveClarificationRequestType">
+		<xs:sequence>
+			<xs:element name="clarificationData" type="clarificationDataType">
+				<xs:annotation>
+					<xs:documentation>
+						Includes the clarification request data, including the organization id.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="RetrieveClarificationRequest" type="RetrieveClarificationRequestType"/>
+	<xs:element name="RetrieveClarificationResponse" type="RetrieveFormResponseType"/>
+</xs:schema>

--- a/wsdl/rfd/RFDFormArchiver.wsdl
+++ b/wsdl/rfd/RFDFormArchiver.wsdl
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+    name="RFDFormArchiver"
+    targetNamespace="urn:ihe:iti:rfd:2007"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:ihe="urn:ihe:iti:rfd:2007"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    
+    <wsdl:documentation>IHE Retrieve Form for Data Capture (RFD) WSDL definitions for FormArchiver.</wsdl:documentation>
+    
+    <wsdl:types>
+        <xsd:schema>
+            <xsd:import namespace="urn:ihe:iti:rfd:2007" schemaLocation="../../schema/rfd/RFD.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+    
+    <wsdl:message name="ArchiveForm_Message">
+        <wsdl:documentation>Archive Form request message.</wsdl:documentation>
+        <wsdl:part name="body" element="ihe:ArchiveFormRequest"/>
+    </wsdl:message>
+    
+    <wsdl:message name="ArchiveFormResponse_Message">
+        <wsdl:documentation>Archive Form response message.</wsdl:documentation>
+        <wsdl:part name="body" element="ihe:ArchiveFormResponse"/>
+    </wsdl:message>
+    
+    <wsdl:portType name="RFDFormArchiver_PortType">
+        <wsdl:operation name="RFDFormArchiver_ArchiveForm">
+            <wsdl:documentation>Corresponds to Transaction ITI-36 of the IHE Technical Framework.</wsdl:documentation>
+            <wsdl:input name="ArchiveForm_Message" message="ihe:ArchiveForm_Message"
+                wsaw:Action="urn:ihe:iti:2007:ArchiveForm"/>
+            <wsdl:output name="ArchiveFormResponse_Message" message="ihe:ArchiveFormResponse_Message"
+                wsaw:Action="urn:ihe:iti:2007:ArchiveFormResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    
+    <wsdl:binding name="RFDFormArchiver_Binding_Soap12" type="ihe:RFDFormArchiver_PortType">
+        <soap12:binding style="document" transport="http://www.w3.org/2003/05/soap/bindings/HTTP/"/>
+        <wsdl:operation name="RFDFormArchiver_ArchiveForm">
+            <soap12:operation style="document" soapAction="urn:ihe:iti:2007:ArchiveForm"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    
+    <wsdl:service name="RFDFormArchiver_Service">
+        <wsdl:port name="RFDFormArchiver_Port_Soap12" binding="ihe:RFDFormArchiver_Binding_Soap12">
+            <soap12:address location="http://localhost/RFDFormArchiver"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/wsdl/rfd/RFDFormManager.wsdl
+++ b/wsdl/rfd/RFDFormManager.wsdl
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+    name="RFDFormManager"
+    targetNamespace="urn:ihe:iti:rfd:2007"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:ihe="urn:ihe:iti:rfd:2007"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    
+    <wsdl:documentation>IHE Retrieve Form for Data Capture (RFD) WSDL definitions for FormManager.</wsdl:documentation>
+    
+    <wsdl:types>
+        <xsd:schema>
+            <xsd:import namespace="urn:ihe:iti:rfd:2007" schemaLocation="../../schema/rfd/RFD.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+    
+    <wsdl:message name="RetrieveForm_Message">
+        <wsdl:documentation>Retrieve Form request message.</wsdl:documentation>
+        <wsdl:part name="body" element="ihe:RetrieveFormRequest"/>
+    </wsdl:message>
+    
+    <wsdl:message name="RetrieveFormResponse_Message">
+        <wsdl:documentation>Retrieve Form response message.</wsdl:documentation>
+        <wsdl:part name="body" element="ihe:RetrieveFormResponse"/>
+    </wsdl:message>
+    
+    <wsdl:message name="RetrieveClarification_Message">
+        <wsdl:documentation>Retrieve Clarification request message.</wsdl:documentation>
+        <wsdl:part name="body" element="ihe:RetrieveClarificationRequest"/>
+    </wsdl:message>
+    
+    <wsdl:message name="RetrieveClarificationResponse_Message">
+        <wsdl:documentation>Retrieve Clarification response message.</wsdl:documentation>
+        <wsdl:part name="body" element="ihe:RetrieveClarificationResponse"/>
+    </wsdl:message>
+    
+    <wsdl:portType name="RFDFormManager_PortType">
+        <wsdl:operation name="RFDFormManager_RetrieveForm">
+            <wsdl:documentation>Corresponds to Transaction ITI-34 of the IHE Technical Framework.</wsdl:documentation>
+            <wsdl:input name="RetrieveForm_Message" message="ihe:RetrieveForm_Message"
+                wsaw:Action="urn:ihe:iti:2007:RetrieveForm"/>
+            <wsdl:output name="RetrieveFormResponse_Message" message="ihe:RetrieveFormResponse_Message"
+                wsaw:Action="urn:ihe:iti:2007:RetrieveFormResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="RFDFormManager_RetrieveClarification">
+            <wsdl:documentation>Corresponds to Transaction ITI-37 of the IHE Technical Framework.</wsdl:documentation>
+            <wsdl:input name="RetrieveClarification_Message" message="ihe:RetrieveClarification_Message"
+                wsaw:Action="urn:ihe:iti:2007:RetrieveClarification"/>
+            <wsdl:output name="RetrieveClarificationResponse_Message" message="ihe:RetrieveClarificationResponse_Message"
+                wsaw:Action="urn:ihe:iti:2007:RetrieveClarificationResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    
+    <wsdl:binding name="RFDFormManager_Binding_Soap12" type="ihe:RFDFormManager_PortType">
+        <soap12:binding style="document" transport="http://www.w3.org/2003/05/soap/bindings/HTTP/"/>
+        <wsdl:operation name="RFDFormManager_RetrieveForm">
+            <soap12:operation style="document" soapAction="urn:ihe:iti:2007:RetrieveForm"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="RFDFormManager_RetrieveClarification">
+            <soap12:operation style="document" soapAction="urn:ihe:iti:2007:RetrieveClarification"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    
+    <wsdl:service name="RFDFormManager_Service">
+        <wsdl:port name="RFDFormManager_Port_Soap12" binding="ihe:RFDFormManager_Binding_Soap12">
+            <soap12:address location="http://localhost/RFDFormManager"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/wsdl/rfd/RFDFormReceiver.wsdl
+++ b/wsdl/rfd/RFDFormReceiver.wsdl
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+    name="RFDFormReceiver"
+    targetNamespace="urn:ihe:iti:rfd:2007"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:ihe="urn:ihe:iti:rfd:2007"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    
+    <wsdl:documentation>IHE Retrieve Form for Data Capture (RFD) WSDL definitions for FormReceiver.</wsdl:documentation>
+    
+    <wsdl:types>
+        <xsd:schema>
+            <xsd:import namespace="urn:ihe:iti:rfd:2007" schemaLocation="../../schema/rfd/RFD.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+    
+    <wsdl:message name="SubmitForm_Message">
+        <wsdl:documentation>Submit Form request message.</wsdl:documentation>
+        <wsdl:part name="body" element="ihe:SubmitFormRequest"/>
+    </wsdl:message>
+    
+    <wsdl:message name="SubmitFormResponse_Message">
+        <wsdl:documentation>Submit Form response message.</wsdl:documentation>
+        <wsdl:part name="body" element="ihe:SubmitFormResponse"/>
+    </wsdl:message>
+    
+    <wsdl:portType name="RFDFormReceiver_PortType">
+        <wsdl:operation name="RFDFormReceiver_SubmitForm">
+            <wsdl:documentation>Corresponds to Transaction ITI-35 of the IHE Technical Framework.</wsdl:documentation>
+            <wsdl:input name="SubmitForm_Message" message="ihe:SubmitForm_Message"
+                wsaw:Action="urn:ihe:iti:2007:SubmitForm"/>
+            <wsdl:output name="SubmitFormResponse_Message" message="ihe:SubmitFormResponse_Message"
+                wsaw:Action="urn:ihe:iti:2007:SubmitFormResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    
+    <wsdl:binding name="RFDFormReceiver_Binding_Soap12" type="ihe:RFDFormReceiver_PortType">
+        <soap12:binding style="document" transport="http://www.w3.org/2003/05/soap/bindings/HTTP/"/>
+        <wsdl:operation name="RFDFormReceiver_SubmitForm">
+            <soap12:operation style="document" soapAction="urn:ihe:iti:2007:SubmitForm"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    
+    <wsdl:service name="RFDFormReceiver_Service">
+        <wsdl:port name="RFDFormReceiver_Port_Soap12" binding="ihe:RFDFormReceiver_Binding_Soap12">
+            <soap12:address location="http://localhost/RFDFormReceiver"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
- Added RFD XSD file (originally retrieved from revision c69022faaaca06bc1af0e58a98ebc66861548dee of the erl-ihe-rfd project; see https://code.imphub.org/projects/IHE/repos/erl-ihe-rfd/).
- Added RFD WSDL files from the working copy tip of the SDCCT project.
